### PR TITLE
Add scheduled Idea to Service OS post series

### DIFF
--- a/.github/workflows/scheduled-pages-rebuild.yml
+++ b/.github/workflows/scheduled-pages-rebuild.yml
@@ -1,0 +1,36 @@
+name: Scheduled Pages Rebuild
+
+on:
+  schedule:
+    - cron: '30 1 * * 0' # Sunday 10:30 JST
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  scheduled_rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Rebuild Marker (JST)
+        run: |
+          mkdir -p .github/rebuild
+          TZ=Asia/Tokyo date "+%Y-%m-%d %H:%M:%S %Z" > .github/rebuild/last_scheduled_rebuild.txt
+
+      - name: Commit and Push
+        run: |
+          git add .github/rebuild/last_scheduled_rebuild.txt
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: scheduled pages rebuild trigger"
+          git push

--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,8 @@ locales:
 #         title: Kyo's Blog
 
 ### Build settings
+future: false
+timezone: Asia/Tokyo
 markdown: kramdown
 kramdown:
   input: GFM

--- a/_posts/2026-05-03-beauty-ai-mvp-to-b2b-api.md
+++ b/_posts/2026-05-03-beauty-ai-mvp-to-b2b-api.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: "From Beauty AI MVP to B2B API: Why a Working Prototype Is Not Yet a Business Service"
+date: 2026-05-03 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [AI, B2B API, MVP, Product Strategy, Beauty AI]
+---
+
+# From Beauty AI MVP to B2B API: Why a Working Prototype Is Not Yet a Business Service
+
+A beauty AI MVP can look deceptively complete.
+
+The camera opens. The user captures an image. The model returns a skin-related assessment. The interface gives a recommendation. From the outside, this can feel like the hard part has already been solved. The product works, the demo is understandable, and the value proposition is easy to explain.
+
+But once the product is reframed as a B2B API service, the center of gravity changes. The question is no longer whether one user can complete one interaction. The question becomes whether another business can rely on the capability and build its own workflow, operations, and customer journey on top of it.
+
+That is a different problem.
+
+The useful lesson in this case is not that an MVP naturally grows into a business service. It usually does not. A prototype becomes a service when product definition, technical architecture, sales motion, and operational constraints are designed together. In a beauty AI context, this distinction matters even more because the product touches personal images, diagnostic-like user expectations, brand trust, and privacy constraints. A working model is only one component of the system.
+
+## The MVP Proves Feasibility, Not Product Boundary
+
+An MVP proves that a specific interaction can be made tangible: a user submits an input, the system processes it, and the application returns a result that feels relevant. That is valuable because it reduces abstraction and gives stakeholders something concrete to react to.
+
+However, an MVP does not automatically define the business product.
+
+For a consumer-facing beauty AI MVP, the natural unit is a user session. For a B2B API, the natural unit is different: integration, reliability, data handling, partner use case, pricing logic, and operational accountability. The technical capability may be shared, but the product boundary is not.
+
+I find this distinction useful because it prevents a common AI product mistake: treating a working model as if it has already solved the business system around it.
+
+A better framing is to treat the MVP as evidence for one layer of the system: feasibility. It shows that the core interaction is plausible. It does not yet prove that the service is commercially packaged, operationally supportable, or easy for a business customer to adopt.
+
+## Business Definition Has to Move with Technical Definition
+
+In this case, the opportunity is to convert a beauty or skin-analysis experience into a reusable service for other companies. That requires a different product definition from a standalone app.
+
+The product has to answer several questions at once: Who is the buyer? What customer problem is being solved? What operational result is expected? In a beauty AI product, these questions become concrete: is the buyer trying to improve online consultation, personalize product recommendation, reduce counseling workload, or create a diagnostic touchpoint inside an existing commerce flow?
+
+Those are not marketing questions added later. They determine what the API must expose, what outputs need to be stable, and what level of explanation a partner needs.
+
+This is why “AI skin analysis API” is not yet a complete product definition. It names a technical category, but not the commercial job. The API still has to be framed around a partner’s business process.
+
+At least at the planning level, PoC and LoI activity can be useful signals, but they should not be treated as confirmed sales or validated revenue. Their value is to sharpen product definition. A PoC should test not only model behavior, but also integration path, budget ownership, deployment scenario, and success criteria.
+
+## Architecture Is the Mechanism Behind the Claim
+
+A B2B API product cannot rely on feature description alone. It needs architecture that explains why the service can be used repeatedly, integrated safely, and operated under imperfect conditions.
+
+For a beauty AI service, architecture has to cover more than model inference. It needs to define how images are received, processed, retained or discarded, associated with consent, transformed into outputs, and returned to partner systems. It also needs boundaries for low-quality input, limited confidence, and output behavior that avoids overclaiming.
+
+In this framing, the diagnostic engine is not merely an internal feature. It becomes a reusable core around which response structure, partner integration, recommendation constraints, and operational monitoring need to be designed.
+
+This is where business thesis and technical thesis connect. If the claim is that a small team can move from MVP to B2B service, the architecture must show operational leverage. The service cannot depend on manual interpretation, ad hoc partner exceptions, or one-off implementation logic. It needs repeatable interfaces.
+
+An API is not just a wrapper around a model. It is a contract.
+
+That contract includes request and response structure, latency assumptions, error handling, authentication, logging, versioning, and documentation. It also includes softer but critical boundaries: what the service does not diagnose, how confidence should be communicated, and which outputs are suitable for end-user display.
+
+## GTM Should Be Designed Before the Product Is “Finished”
+
+A common failure mode in MVP-to-B2B transitions is to finish the product first and then look for customers. That feels clean, especially for technical teams. In practice, it tends to fail.
+
+B2B productization is not a simple handoff from build to sell. Sales motion reveals requirements that the product must absorb.
+
+For a beauty AI API, a realistic path likely includes structured PoCs, partner-specific integration discussions, and clear stage definitions for what the buyer receives. The point is not to inflate PoC planning into confirmed demand. The point is that PoC design is part of product design.
+
+A useful PoC should clarify whether a partner can integrate with reasonable effort, whether outputs support its customer journey, whether result categories are understandable to end users, and whether ownership and adoption metrics are clear enough for internal decision-making.
+
+Without this sales attachment, a product can remain a technically strong demo that does not travel. B2B products must travel across organizations: initial conversation, technical review, pilot, budget decision, and operation. Each stage imposes different constraints, and the API product has to be legible across all of them.
+
+## Operations, Privacy, and Review Constraints Cannot Be Postscript
+
+One fragile assumption in AI MVP work is that operational and compliance issues can be solved after core functionality works. In practice, they often determine whether the service can launch or be sold.
+
+For beauty AI products, image handling is central. Even without medical claims, users still submit personal visual data. Consent flow, retention policy, and partner responsibilities have to be explicit. If these remain vague, the service may be technically implemented but commercially blocked.
+
+Platform review constraints matter as well when consumer-facing components are involved. It is unsafe to assume approval in advance. Review readiness, privacy design, and operational quality should be treated as launch constraints, not administrative cleanup.
+
+The same applies to support and change management: escalation paths, known failure conditions, and versioning behavior all affect whether a partner can trust the service in production.
+
+A prototype proves that a flow can work under early conditions. A service requires defined behavior under imperfect conditions.
+
+## Domain Specificity Is a Strength and a Boundary
+
+Beauty and skin-analysis context gives the product concrete shape. That is a strength because it forces clear use cases and prevents generic AI packaging.
+
+At the same time, this context also defines boundaries. A beauty AI API has distinct concerns around image interpretation, recommendation framing, and trust. Those constraints are not interchangeable with every other API category.
+
+So the general lesson is not “any MVP can become a B2B API.” A more precise lesson is this: an MVP can become a B2B service when its core capability is redefined as a repeatable business interface, and when the surrounding system is designed for adoption, operation, and accountability.
+
+## Practical Takeaway
+
+The transition from beauty AI MVP to B2B API is not a matter of adding one endpoint to an existing prototype. It is a redesign of the product boundary.
+
+The MVP asks: can this interaction work?
+
+The B2B API must ask: can another business rely on this capability, integrate it into its workflow, explain it to users, satisfy review constraints, and justify paying for it?
+
+An operating principle follows: before calling an MVP a service, test whether buyer workflow, API contract, commercial path, and operational constraints are already coupled in one design, not scattered across separate documents and separate conversations.

--- a/_posts/2026-05-10-ai-services-dont-need-to-look-like-ai-products.md
+++ b/_posts/2026-05-10-ai-services-dont-need-to-look-like-ai-products.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: "AI Services Do Not Need to Look Like AI Products"
+date: 2026-05-10 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [AI, Workflow Design, B2B, Product Positioning, Service Design]
+---
+
+# AI-Built Services Do Not Have to Look Like AI Products
+
+## Designing B2B workflow value before designing AI branding
+
+An MVP can work technically and still fail to become a business service. This is the tension I keep seeing in AI-enabled product planning: a prototype can process inputs, generate outputs, and demonstrate a plausible automation flow, yet still leave unanswered the harder commercial question—what operational problem does this remove, who pays for that removal, and how does the product enter an existing workflow?
+
+That distinction matters because many AI projects are framed too early as “AI products.” The interface, model behavior, and generated output become the center of the plan. But in B2B contexts, the buyer usually does not purchase “AI” as an abstract capability. They purchase reduced manual work, faster decision cycles, better customer-facing experiences, lower operational friction, or a more scalable way to deliver an existing service.
+
+The more useful framing is therefore not, “What AI product can we build?” It is, “What business workflow can we make easier to operate, and where does AI become the mechanism behind that improvement?”
+
+In the case I am using as the basis for this article, the product concept sits in a beauty and skin-analysis domain. The exact domain matters because the service is not merely a generic AI wrapper. It depends on a specific customer problem, a specific business adoption path, and a specific set of operational constraints around review, privacy, and launch readiness. But the broader lesson generalizes: turning an AI-enabled idea into a B2B service requires simultaneous design across business plan, technical architecture, go-to-market path, and operational constraints.
+
+The core point is simple but easy to underestimate: AI can be the production method without being the value proposition.
+
+## The MVP is only one layer of the service
+
+A working MVP usually proves that a technical loop can be closed. A user submits something, the system processes it, and an output appears. For an individual developer or small team, that is an important milestone. It converts ambiguity into something inspectable.
+
+But B2B service design has a different threshold. A business service must define the user, the buyer, the workflow, the value metric, the delivery surface, and the conditions under which the output can be trusted enough to enter operations. Without those pieces, the MVP remains a demonstration of capability rather than a productized service.
+
+AI does not remove these questions. It makes them more important, because AI output can look impressive before the business process around it is stable.
+
+## Business plan logic: define the job before the technology
+
+The business plan layer fixes the service in commercial reality. It identifies the customer problem, the value proposition, the revenue assumption, and the competitive basis. This does not mean every number must be proven at the planning stage. It does mean that the claim must be narrow enough to match the evidence available.
+
+That framing changes the product. The service is no longer a generic “AI app.” It becomes an enablement layer for another company’s workflow. The value is not novelty. The value is that the client can add or improve a customer-facing process without owning the full technical and operational burden.
+
+This also changes how revenue assumptions should be discussed. At the planning stage, it is reasonable to describe possible monetization paths, such as API usage, B2B licensing, or service integration. It would not be reasonable to imply actual revenue, signed customers, or proven commercial traction unless those facts exist. For an early-stage product, commercial discipline means separating “designed to be sellable” from “already sold.”
+
+That distinction is not cosmetic. It determines how the team should prioritize work. If the product is intended to become a B2B workflow service, then the plan must include not only what the system does, but also why a business would integrate it, how adoption could begin, and what evidence is needed next.
+
+## Technical architecture as a mechanism, not a feature list
+
+The technical layer should explain how the service works as an operational mechanism. This is different from listing components. A list of APIs, models, storage layers, and front-end screens can describe implementation, but it does not automatically explain why the service can support a workflow.
+
+In B2B productization, architecture should connect inputs, processing, outputs, controls, and operational responsibilities. The question is not only whether AI can generate an analysis. The question is whether the system can consistently produce an output that fits the client’s use case, can be reviewed or constrained where necessary, and can be delivered through a surface that matches the business model.
+
+For a skin-analysis workflow, this means the domain-specific logic cannot be treated as decoration. The service has to reflect the actual context in which the analysis is used. If the domain requirements are removed, the remaining architecture may still look technically plausible, but the business claim becomes weaker. A general image-processing or recommendation flow is not the same as a workflow designed for beauty-related customer interaction.
+
+This is where many AI products become too abstract. They emphasize the model’s ability to interpret, classify, summarize, or recommend. Those abilities may be necessary, but they are not sufficient. The architecture needs to show how those capabilities become a reliable service boundary: what the system accepts, what it returns, what it avoids claiming, and how it supports downstream action.
+
+The more operational the product becomes, the more technical architecture and product definition converge. The API is not just an endpoint. It is a contract. The output is not just generated text or analysis. It is a unit of workflow value. The system design must therefore be written as a causal chain: because the service structures this input in this way, the client can perform this workflow with less friction.
+
+## The anti-pattern: selling “AI” instead of workflow completion
+
+The clearest anti-pattern is to brand the product around AI capability while leaving the workflow vague.
+
+In this pattern, the product pitch says the service uses AI to analyze, recommend, personalize, or automate. The demo may look polished. The model may produce plausible results. But the buyer still has to infer how the service maps to their operations. They have to decide where it fits, who uses it, what process changes, what risk it introduces, and how success should be measured.
+
+That creates a sales burden. The product is asking the buyer to perform the workflow design themselves.
+
+For small teams, this is especially costly because they usually cannot compensate with enterprise sales capacity, extensive customization, or long implementation cycles. The product has to carry more of the explanation in its structure. It should be legible as a workflow improvement before it is legible as an AI system.
+
+A better pitch starts with the operational job. For example: “We help beauty businesses add structured skin-analysis guidance to their digital customer journey without building the analysis infrastructure themselves.” AI can then be explained as the mechanism that makes the service scalable or responsive. This ordering is important. If AI comes first, the buyer evaluates novelty. If workflow value comes first, the buyer evaluates fit.
+
+AI may still be part of differentiation in some contexts, but it cannot be the only differentiator. If the service cannot explain its value without leaning on the word “AI,” the product definition is still too thin.
+
+## GTM: productization needs a sales path, not just a launch surface
+
+A B2B service also needs a route into the market. For early-stage teams, this does not require pretending that customers are already signed or that revenue has already materialized. It does require defining how the product could be tested with real business users.
+
+The safer interpretation is that MVP completion alone is not enough. The product needs connection to PoC planning, lead generation, partner discussions, or another concrete sales path. Without that connection, the product may be technically complete but commercially suspended.
+
+This is where API productization becomes important. If the service is intended to support other businesses, then the product surface may not need to be a standalone consumer-facing app. It may be an API, dashboard, embeddable flow, or managed workflow component. The right surface depends on who owns the customer relationship and where the analysis output creates value.
+
+For a small team, the key GTM question is not “How do we make this look like a big AI platform?” It is “What is the smallest credible adoption path for a business customer?” That may be a limited PoC with a narrow workflow, a partner-led pilot, or a constrained integration that proves operational usefulness before expanding scope.
+
+This forces useful discipline. It prevents the team from overbuilding generic features and instead pushes the product toward a testable commercial unit. A good B2B AI-enabled service should be able to answer: what does the client try first, what result do they inspect, and what would justify continuing?
+
+## Operations, privacy, and review are part of product design
+
+The most common mistake is to treat operational constraints as post-launch cleanup. In AI-enabled services, that is rarely safe. Review requirements, privacy handling, quality control, and platform approval can block productization even after implementation appears complete.
+
+This is also why cautious wording matters. It is acceptable to say that the product is designed with these constraints in mind if the design work supports that statement. It is not acceptable to claim compliance completion, approval, or full operational readiness unless those milestones have actually occurred.
+
+Operational realism is not pessimism. It is what turns a prototype into something a business can evaluate seriously.
+
+## The boundary of generalization
+
+The broader principle is not that every AI-enabled product should become a B2B API. Nor is it that AI branding is always bad. The principle is narrower and more useful: when the target is a business workflow, the service should be designed around the workflow outcome, with AI positioned as the mechanism that makes the outcome feasible or scalable.
+
+For individual developers and small teams, this is a productive constraint. It reduces the temptation to build a general AI product and then search for a market. Instead, it asks the team to define a specific operational gap, design the technical system as a mechanism for closing that gap, and connect the product to a credible sales path.
+
+The next decision criterion is therefore practical: can the product be described as a workflow improvement without using AI as the main noun?
+
+If the answer is no, the service definition is not yet strong enough. If the answer is yes, the team can then decide where AI belongs in the architecture, how the product should be packaged, what evidence is needed for a PoC, and which operational constraints must be resolved before launch.
+
+That is the useful inversion. AI may build the service, power the service, and differentiate parts of the service. But the thing being sold should usually be the business outcome: a workflow made easier to deliver, easier to repeat, or easier to scale.
+
+---

--- a/_posts/2026-05-17-from-prompt-to-product-boundary.md
+++ b/_posts/2026-05-17-from-prompt-to-product-boundary.md
@@ -1,0 +1,131 @@
+---
+layout: post
+title: "From Prompt to Product Boundary: The Missing Definition Layer"
+date: 2026-05-17 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [AI, Prompting, Product Boundary, API Contract, B2B]
+---
+
+# From Prompt to Product Boundary
+
+## Why B2B AI Services Need API Contracts, Non-Goals, and Integration Scope Before They Need More Features
+
+An AI prototype can look surprisingly complete before it has become a business service. The model responds. The screen works. A user can enter an image, a prompt, a profile, or a business question and receive something that looks useful. From the builder’s side, this often feels like the hard part has been solved.
+
+But in a B2B setting, that is usually where the real product definition starts. A working AI flow is not yet a service that a client can buy, integrate, trust, operate, and explain internally. The gap is not only technical. It is the absence of a boundary.
+
+I have started to think of this boundary as the moment when a prompt stops being an open-ended instruction and becomes a product contract. The contract does not only say what the AI should generate. It says what the product accepts, what it returns, what it refuses to handle, what operational assumptions it depends on, and how a customer organization can fit it into an existing workflow.
+
+In practice, AI product ideas can fail in a quiet way. They do not fail because the model cannot produce an answer. They fail because nobody can say exactly where the service begins and ends.
+
+The useful question is therefore not, “Can we make the AI do this?” The more productive question is, “Can we define a narrow enough service boundary that business planning, technical implementation, sales motion, privacy review, and operations all point to the same object?”
+
+In this article, that boundary is defined through three linked decisions: API contract, explicit non-goals, and integration scope.
+
+## MVP Is Not the Same as a Business Service
+
+This distinction becomes especially important when the AI feature sits inside a domain workflow, such as beauty, skin analysis, customer support, procurement, compliance review, or internal reporting. In those contexts, the value does not come from generic AI capability. It comes from whether the service maps to a buyer’s existing pain, language, decision process, and tolerance for risk.
+
+If these questions are not answered together, the team may keep adding features while the product boundary remains unresolved. The result is a prototype that becomes more impressive in demos but not necessarily easier to sell, deploy, or operate.
+
+## The Product Boundary Starts with the Business Claim
+
+The first boundary is not an API schema. It is the business claim.
+
+A B2B AI service needs a clear statement of what customer problem it addresses and why the customer would pay for that particular solution. This sounds obvious, but AI prototypes often skip this discipline because the generated output itself feels novel enough to justify the product. That is a weak foundation.
+
+For example, if a service is positioned around domain-specific diagnosis, recommendation, or workflow support, the business claim must be anchored in a concrete user or organizational problem. A generic statement such as “AI can provide personalized advice” is too broad. It does not define a buyer, a workflow, or a purchasing reason.
+
+A stronger claim would specify the operational pain: perhaps staff need faster pre-consultation support, customers need structured guidance before choosing a service, or a business wants to standardize how recommendations are presented. Even then, the claim should be cautious unless there is evidence of actual adoption or revenue. Planning-level evidence can support product direction, but it should not be inflated into proof of market traction.
+
+This is where non-goals become useful. A non-goal is not a weakness. It is a product design instrument. By saying what the service does not attempt to do, the team protects the claim from expanding beyond the evidence.
+
+A beauty-related AI service, for instance, may support structured consultation or recommendation workflows without claiming to replace professionals, certify outcomes, or satisfy all regulatory review requirements. That kind of boundary makes the business claim more credible because it prevents the product from promising the broadest possible interpretation of its demo.
+
+## The API Contract Is a Business Artifact, Not Just a Technical One
+
+Once the business claim is narrowed, the API contract becomes the operational version of that claim.
+
+In a conventional software project, an API contract defines inputs, outputs, errors, authentication, and versioning. In an AI service, that contract also has to define semantic responsibility. What does the request represent? What assumptions are attached to the input? What confidence or explanation should accompany the output? What should the system do when input quality is low? What is the difference between a valid response, a partial response, and a refusal?
+
+This is not just engineering detail. It determines whether the service can be integrated into a customer’s workflow.
+
+If the API accepts an image, user profile, free-text concern, or business context, the contract should specify minimum viable input conditions. If the output contains recommendations, scores, summaries, or next actions, the contract should define how those outputs are meant to be interpreted. If the AI is used in a domain where user trust or business liability matters, the service should expose enough structure for downstream systems and human operators to handle uncertainty.
+
+A vague prompt hides these decisions inside natural language. A product contract externalizes them.
+
+That is the transition from “ask the model to do the task” to “design a service that can be called, monitored, reviewed, and improved.” The model may remain probabilistic, but the surrounding product surface cannot remain vague.
+
+## The Anti-Pattern: Prompt Expansion Without Product Narrowing
+
+The most common anti-pattern I see is prompt expansion without product narrowing.
+
+The team observes that the model can handle more cases than expected, so it keeps broadening the prompt. More user types, more domains, more output formats, more edge cases, more languages, more business scenarios. Each expansion feels like progress because the demo becomes more flexible.
+
+But flexibility at the prompt layer can create ambiguity at the product layer. Sales becomes harder because the product is difficult to describe. Implementation becomes harder because the output contract keeps shifting. Review becomes harder because privacy, compliance, and quality requirements differ by use case. Operations become harder because failure modes multiply.
+
+This is why a B2B AI product should not treat “the model can probably handle it” as a sufficient reason to include a use case. The better criterion is whether the use case fits the product boundary: same buyer, same workflow, same input assumptions, same review requirements, same integration surface, and same value logic.
+
+A prompt can be broad. A product should be narrow enough to be accountable.
+
+## A Short Boundary Checklist
+
+Before expanding an AI service, I would check five boundaries in one pass:
+
+- the customer problem the service directly serves
+- the input contract required for that problem
+- the output contract a customer can act on
+- the non-goals that prevent overclaiming
+- the integration points needed for workflow adoption
+
+If any one of these is unclear, the next task is probably not feature development. It is boundary definition.
+
+## Technical Architecture Should Explain Operability
+
+Technical architecture is often described as a stack: model, backend, database, frontend, deployment. That description is necessary, but it is not enough for productization.
+
+For a B2B AI service, architecture should explain why the service can operate under the business claim. The architecture should connect the domain workflow to data handling, model invocation, output structuring, human review, logging, monitoring, and failure handling.
+
+For example, if a service provides domain-specific recommendations, the architecture should make clear how domain context enters the system, how outputs are constrained, and how the product avoids unsupported claims. If the service requires privacy-sensitive inputs, the architecture should explain what is stored, what is transient, what is excluded, and how user consent or organizational policy is reflected in the system design. If the service is intended to support customer-facing operations, the architecture should account for latency, review paths, fallback behavior, and quality control.
+
+This is not because every early product needs enterprise-grade infrastructure from day one. It is because the architecture must match the seriousness of the claim. A lightweight prototype can be appropriate, but it should not be described as if it already satisfies operational requirements that have not been implemented or reviewed.
+
+The discipline is to describe mechanism, not aspiration. What exists? What is planned? What still requires validation? A credible product narrative separates these states clearly.
+
+## GTM Turns the Boundary into a Sales Path
+
+A product boundary also changes the go-to-market discussion.
+
+For a small team building an AI business service, this attachment point is often more important than the sophistication of the model. The question is where the service enters the buyer’s process. Is it a pre-sales tool? A staff productivity layer? A customer self-service module? A decision-support API embedded into an existing system? A reporting automation product? Each answer implies a different buyer, proof requirement, integration burden, and pricing logic.
+
+At the same time, planning a PoC is not the same as having customers. Interest, outreach, and proposed pilots should be described as validation steps, not revenue evidence. This distinction may feel conservative, but it makes the product story stronger. It keeps the claim aligned with what has actually been established.
+
+## Operations, Privacy, and Review Are Product Constraints
+
+Many AI services reach a painful point where the implementation is mostly complete, but launch is blocked by review, privacy, operational quality, or platform constraints. This is not an accidental delay. It is usually a sign that those constraints were not included early enough in the product boundary.
+
+This does not mean a small team must solve every enterprise requirement upfront. It means the service boundary should state which constraints are currently handled, which are planned, and which use cases are intentionally excluded until the product is ready for them.
+
+## Domain Grounding Defines What Can Be Generalized
+
+There is a final tension in AI product design: the desire to generalize.
+
+A domain-specific service often contains insights that can apply elsewhere. The boundary logic, API contract design, non-goal discipline, and integration thinking are broadly reusable. But the evidence for one domain does not automatically validate another.
+
+If the product is grounded in a beauty or skin-analysis workflow, then the domain assumptions matter. The customer concern, recommendation language, trust model, review needs, and acceptable output format are shaped by that context. Removing the domain may leave a useful framework, but it weakens the implementation argument unless the new domain is separately validated.
+
+This is the right way to generalize: extract the operating principle, not the outcome claim.
+
+The principle is that AI productization depends on simultaneous design across business, technology, GTM, and operations. The domain provides the concrete case, and the boundary is kept explicit through API contract, non-goals, and integration scope.
+
+## Practical Takeaway: Define the Boundary Before Expanding the Product
+
+The practical implication for an individual developer or small team is simple but demanding: do not let the prompt be the product definition.
+
+A prompt is useful for exploration. It helps discover what the model can do, what users react to, and what a possible workflow might look like. But once the goal becomes a business service, the prompt has to be surrounded by contracts: business claim, API schema, non-goals, integration scope, review assumptions, and operational responsibilities.
+
+The next decision criterion is therefore not whether another feature can be added. It is whether the current service boundary is sharp enough for a customer to understand, a developer to implement, a sales conversation to test, and an operator to support.
+
+When those pieces are designed together, an AI idea has a path toward becoming a business service. Without them, even a strong MVP can remain only a capable demo.
+
+---

--- a/_posts/2026-05-24-architecture-contract-before-model-polish.md
+++ b/_posts/2026-05-24-architecture-contract-before-model-polish.md
@@ -1,0 +1,59 @@
+---
+layout: post
+title: "Architecture as Contract: Why API Core Beats Demo Polish"
+date: 2026-05-24 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [AI Architecture, API Contract, Repeatability, Monitoring, Versioning]
+---
+
+# API Contracts Before Model Polish
+
+## Why B2B AI Services Need Repeatability, Monitoring, and Versioning Before They Need Better Demos
+
+An MVP can look convincing while still being structurally unready as a business service. I see this most clearly in AI applications that produce a useful result once, under controlled conditions, with a friendly operator watching the output. The demo works. The workflow is understandable. The value proposition is plausible. Yet the moment the service must be attached to another company’s operation, the real question changes: not “does the model work?” but “can another business depend on this behavior repeatedly?”
+
+That shift is easy to underestimate. In some consumer-facing AI prototypes, users may tolerate more ambiguity than they would in an operational B2B workflow. The interface can absorb variation. The operator can explain what happened after the fact. In a B2B service, especially one exposed through an API, ambiguity becomes a commercial constraint. The customer is not buying a clever response. They are buying an operational boundary that can be integrated, monitored, versioned, and trusted.
+
+This is why I increasingly think the API contract should be designed before model polish becomes the center of attention. Not because model quality is unimportant, but because model quality without a service boundary is difficult to sell, difficult to operate, and difficult to improve safely. A B2B AI product is not merely a model wrapped in an endpoint. It is a promise about inputs, outputs, failure modes, data handling, and change management.
+
+The practical thesis is simple: an AI idea becomes a business service only when business planning, technical implementation, go-to-market design, and operational constraints are designed together. If these layers are separated, the project can still produce a working prototype. What it may not produce is a repeatable service.
+
+The business plan has to define what the API contract is for. This sounds obvious, but it is often skipped. A team may describe the model capability in broad terms: diagnosis, recommendation, extraction, scoring, personalization, automation. These verbs are useful for exploration, but they are too loose for productization. A customer cannot integrate “personalization” into an existing workflow. They can integrate a request schema, a response schema, confidence fields, status codes, latency expectations, and an escalation path.
+
+That means the business plan should specify not only the customer problem, but also the operational unit of value. Is the service returning a classification that triggers a human review? Is it generating a recommendation that a staff member can edit? Is it producing a structured assessment that must be stored in a customer system? Each answer implies a different contract. The same model capability can become different products depending on where the boundary is drawn.
+
+This is also where monetization assumptions become more concrete. A vague AI feature is hard to price because its value is narrative. A repeatable API operation is easier to reason about because its value is connected to usage, workflow replacement, quality assurance, or attachment to an existing business process. Even before revenue is proven, the plan becomes more testable when the service unit is explicit.
+
+The technical mechanism follows from that service unit. In an API-first B2B AI service, the key architecture question is not only how to improve inference. It is how to make inference governable. The system needs stable input contracts, constrained output structures, traceable execution, and observable quality signals. Otherwise, every model update becomes a potential product change, and every customer integration becomes a special case.
+
+Repeatability begins with input discipline. The system should define what fields are required, what fields are optional, what formats are accepted, and what happens when the request is incomplete or out of scope. This is not just backend hygiene. It is part of the product promise. If the service accepts arbitrary inputs and tries to be helpful in all cases, it may feel flexible during a demo, but it becomes difficult to operate in production-like settings.
+
+The same is true on the output side. A B2B AI service should avoid treating prose as the primary integration artifact unless prose itself is the product. For many operational use cases, the useful output is a structured object: categories, scores, reasons, recommendations, flags, next actions, and context fields. The model may generate or assist with these fields, but the contract should define them independently of any single prompt or model version.
+
+This separation matters because the API contract is the customer-facing stability layer. The internal model can change. Prompts can be revised. Retrieval logic can improve. Guardrails can be tightened. But the customer’s system should not break because an internal implementation detail changed. Without that separation, technical iteration becomes commercially dangerous.
+
+Monitoring is the next layer of the same argument. In a simple prototype, evaluation can be manual and episodic. Someone checks sample outputs, decides whether they look reasonable, and adjusts prompts or thresholds. In a B2B service, that is not enough. The system needs to know whether the service is behaving within expected ranges over time.
+
+This does not necessarily require a large, sophisticated evaluation platform from day one. For a small team, the important point is to decide what must be observed. Request volume, error rates, latency, fallback frequency, schema validation failures, low-confidence outputs, human override rates, and version-specific behavior can be more useful early indicators than a single abstract model-quality score. They connect directly to service reliability.
+
+This is where API architecture and business risk meet. If a customer depends on the service inside an operational workflow, silent degradation is more dangerous than visible failure. A structured failure response may be commercially acceptable. An untracked change in recommendation behavior may not be. The API should therefore make failure observable, not merely avoid it.
+
+Versioning is the third requirement. AI teams often think about versioning as a model-management problem, but for B2B service design, API versioning is the more important commercial interface. Customers need to know whether the behavior they integrated last month will remain stable next month. They also need a way to adopt improvements without being forced into unexpected changes.
+
+A practical architecture should distinguish at least three layers of versioning: the external API version, the output schema version, and the model or prompt version. These should not be collapsed into one label. A model can change while the API contract remains stable. A schema can evolve while old clients continue using the previous version. A new API version can introduce a different service boundary when the product itself changes.
+
+This discipline prevents a common failure mode: treating every internal improvement as a customer-visible upgrade. In B2B settings, improvement is not automatically valuable if it changes downstream behavior without coordination. A more accurate result can still be operationally disruptive if the customer has built review rules, dashboards, or staff procedures around the previous output distribution.
+
+The service boundary also prevents overcustomization. Without a clear contract, many customer requests can become potential forks: a slightly different field, a slightly different prompt, a slightly different review process. Some customization may be necessary in early deals, but uncontrolled variation destroys repeatability. The architecture should define where adaptation is allowed and where the product remains fixed.
+
+Operational and privacy constraints belong in the same design conversation, not after launch planning. If the service handles sensitive images, personal attributes, business records, or domain-specific assessments, then data retention, consent, review, and deletion behavior are not legal decorations. They are part of the service interface. A customer needs to know what data is sent, what is stored, what is logged, and what is used for improvement.
+
+This is especially important for AI services that appear simple at the user interface level. A clean front end can hide complicated obligations. If the product requires external review, platform approval, privacy disclosure, or human escalation, those constraints can delay or block business service deployment even after implementation work is largely complete. The lesson is not to avoid regulated or sensitive domains. The lesson is to treat reviewability and privacy posture as product requirements.
+
+There is a boundary to this argument. A small team does not need enterprise-grade infrastructure before testing demand. Overbuilding the platform can be just as damaging as underbuilding it. The point is not to create a heavy architecture prematurely. The point is to identify which contracts must be stable for the next commercial step.
+
+For an early PoC, that may mean a simple but explicit request schema, deterministic response structure, manual monitoring, and a version log. For a paid pilot, it may mean stricter validation, customer-specific access control, dashboarded operational metrics, and a change policy. For broader deployment, it may require stronger auditability, privacy controls, support processes, and formal version migration.
+
+The practical decision criterion is therefore not “is the model good enough?” It is “which service boundary are we asking a customer to trust?” Once that boundary is clear, model improvement becomes easier to prioritize. Monitoring tells the team where the service is unstable. Versioning allows improvement without breaking customers. The API contract turns a promising AI capability into something that can be evaluated, sold, and operated.
+
+For individual developers and small teams, this is a useful constraint. It narrows the work. Instead of polishing every part of the AI system, the team can focus on the smallest repeatable contract that connects a real customer problem to a technical mechanism and a sales path. That contract is not merely an implementation detail. It is the point where the idea starts becoming a business service.

--- a/_posts/2026-05-31-gtm-attached-development-design-before-launch.md
+++ b/_posts/2026-05-31-gtm-attached-development-design-before-launch.md
@@ -1,0 +1,91 @@
+---
+layout: post
+title: "GTM-attached Development: Designing PoC and LoI as Product Inputs"
+date: 2026-05-31 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [GTM, PoC, LoI, B2B Sales, Productization]
+---
+
+# From MVP to B2B API Product
+
+## Why PoC and LoI planning must be connected to product definition before launch
+
+A working MVP can create a misleading sense of progress. The interface responds, the core workflow is visible, and the first version may be good enough to demonstrate the idea. Yet, when the intended buyer is a business customer rather than an individual user, that is still not the same as having a business service.
+
+I have seen this tension most clearly in products that begin as small, focused applications and then try to move into B2B use cases. The early product proves that something can be built. The next question is different: can it be packaged, integrated, reviewed, sold, and operated as part of another company’s workflow? That second question is where many MVPs stall.
+
+The case here is a development plan for a beauty and skin-diagnosis product that is being reframed as a B2B API-enabled service. The important point is not that commercial traction has already been proven. It has not. The useful signal is more limited and more practical: the product is being redesigned so that PoC discussions, potential letters of intent, technical architecture, and sales routing are considered together rather than sequentially.
+
+That distinction matters. A PoC plan is not revenue. A letter-of-intent discussion is not a signed customer. A launch checklist is not operational maturity. But these planning signals can still be valuable if they force the product definition to become more concrete. They turn “we built an app” into “we can describe the business problem, integration surface, buyer path, and operating constraints well enough for a B2B conversation.”
+
+The general lesson is that an MVP does not become a B2B API product by adding an endpoint. It becomes one when the product’s technical shape and commercial shape start to reinforce each other.
+
+## The product definition has to change before the sales story can change
+
+A consumer-facing MVP is usually organized around visible user value. The question is whether the end user can complete a task, receive an output, and understand the benefit. That is a valid starting point, especially for a solo or small-team project.
+
+A B2B API product requires a different definition. The buyer is not only buying the output. The buyer is buying an operational component: something that may be embedded into an existing customer journey, evaluated by a business owner, reviewed by legal or compliance stakeholders, and maintained after the first demonstration.
+
+This is why the product must be redefined before the sales story becomes credible. In the skin-diagnosis context, the value proposition cannot remain at the level of “the app analyzes skin condition.” That may describe the feature, but it does not yet define the business service. A stronger B2B definition asks where the diagnostic capability attaches: a beauty retailer’s consultation flow, a clinic’s pre-counseling process, a CRM-triggered recommendation journey, or a partner’s digital customer experience.
+
+Each attachment point changes the product. It affects what the API must return, how confidence or uncertainty should be expressed, what data needs to be retained or discarded, and how the result should be explained to the business user. The product definition therefore cannot be separated from the commercial route.
+
+This is where PoC and LoI planning become useful, but only if treated carefully. They should not be presented as proof of market traction. They should be used as pressure tests. A PoC proposal can clarify what a partner would need to test. An LoI conversation can clarify which buyer would care enough to continue. Neither confirms demand by itself. But both can expose whether the MVP has been defined in a way that a business customer can actually evaluate.
+
+## The business plan is not a slide; it is a constraint on the product
+
+The business plan logic in this type of transition should do more than describe a target market. It should constrain the product design. If the product is intended for B2B use, then customer problem, value proposition, pricing premise, and delivery model have to be designed together.
+
+A more disciplined approach is to start from the narrowest credible business problem. For example, the product might initially be framed as a diagnostic API that helps a beauty-related partner provide structured skin-condition input before product recommendation or consultation. That is still a planning-level claim, not a proven revenue model. But it is specific enough to shape the product.
+
+From there, the business logic can become testable. What would the partner measure during a PoC? Shorter consultation time, better recommendation completion, higher repeat engagement, or improved staff consistency? What evidence would justify continuation? What would be unacceptable from a privacy or review perspective? These questions are commercial, but they directly influence technical design.
+
+## Technical architecture is the mechanism, not the decoration
+
+When a product is reframed as a B2B API service, technical architecture becomes part of the business argument. It is not enough to list the stack or describe the model. The architecture has to explain why the service can be integrated, evaluated, operated, and controlled.
+
+In the skin-diagnosis case, the technical mechanism would need to involve several layers: an input interface, image or profile processing, diagnostic logic, recommendation-related output, API access, logging, and operational monitoring. The exact implementation can vary. What matters for productization is that each layer has a business reason.
+
+The API layer, for example, is not just a developer convenience. It defines how the product can be embedded into a partner’s workflow. The output schema is not just a formatting decision. It determines whether the partner can use the result in a recommendation engine, staff dashboard, CRM event, or customer-facing explanation. The logging layer is not just for debugging. It becomes part of quality review, incident investigation, and PoC evaluation.
+
+This is also where evidence strength should discipline the claim. If the product is still in planning or MVP-stage development, it is safer to say that the architecture is being designed to support B2B operation, not that it already proves enterprise-grade reliability. The former is useful and supported by the design direction. The latter would overstate the state of the business.
+
+The same applies to AI or diagnostic capability. It is reasonable to describe the product as using diagnostic logic in a beauty or skin-analysis context if that is the domain design. It is not reasonable to imply medical validation, compliance completion, or production-grade accuracy unless those have been separately established. In B2B productization, overstating the technical claim can damage the sales process because serious buyers will eventually ask for the operating evidence.
+
+## GTM attachment is where the MVP becomes legible to buyers
+
+The GTM problem is often misunderstood as a post-launch activity. In reality, for B2B API products, GTM has to be attached during product definition. Otherwise, the team may build something that is technically coherent but commercially difficult to sell.
+
+The important GTM question is not simply “who might want this?” It is “where does this product attach to an existing budget, workflow, or decision process?” For a beauty and skin-diagnosis API, the attachment point may be a digital consultation, product recommendation flow, loyalty program, CRM campaign, or partner service layer. Each route implies a different buyer and a different proof requirement.
+
+PoC planning is useful here because it forces the sales path to become operational. A vague partner conversation can remain at the level of interest. A PoC plan needs a scope, a data boundary, a success criterion, and a next step. A possible LoI can indicate that a partner is willing to formalize intent, but it should still be treated as a planning signal unless signed and tied to specific commercial terms.
+
+This distinction should appear in every serious B2B narrative. Planning signals can support a claim that the product is being prepared for business development. They cannot support a claim that the market has already accepted the product.
+
+For this kind of transition, a practical GTM design separates three stages. First, define the API product and its partner-facing use case. Second, run a limited PoC that tests integration feasibility and business usefulness. Third, use the result to decide whether the product deserves commercial packaging, pricing, and operational hardening. That sequence is slower than declaring traction early, but it is more credible.
+
+## The anti-pattern: treating review, privacy, and operations as launch cleanup
+
+The clearest anti-pattern in this type of product transition is treating operational constraints as something to clean up after the MVP is done. That may work for a prototype. It does not work for a B2B service.
+
+This is why the launch path should be described with careful boundaries. The product may be designed toward B2B operation. It may have a PoC route. It may be preparing for privacy review, partner evaluation, and operational checks. But unless those steps are complete, the public claim should remain at the level of planned readiness rather than achieved readiness.
+
+## Domain grounding matters, but it should not be confused with universal proof
+
+The beauty and skin-diagnosis domain is not incidental. It shapes the product’s requirements. A generic API story would miss important details: image quality, user consent, subjective interpretation, recommendation context, and the boundary between cosmetic advice and stronger diagnostic claims. Removing the domain would make the lesson cleaner but less grounded.
+
+At the same time, the case has a more general implication. Many MVPs fail to become B2B products because they are defined around the builder’s implementation rather than the buyer’s adoption path. The API endpoint exists, but the business use case is vague. The demo works, but the PoC scope is undefined. The pitch mentions partners, but the operational constraints are not yet addressed.
+
+The transferable rule is therefore not “turn every MVP into an API.” It is more specific: when the intended customer is a business, product definition must include the integration surface, proof path, buyer workflow, and operating boundary. The API is only valuable if it makes those elements easier to evaluate.
+
+## Practical takeaway: define the B2B product before claiming the B2B business
+
+The practical implication is straightforward. Before claiming that an MVP is ready for B2B sales, define the smallest business-service version of the product.
+
+That definition should answer five questions. What business workflow does the product attach to? What API or delivery surface makes that attachment possible? What will a PoC actually test? What would a potential LoI mean, and what would it not mean? What privacy, review, and operational constraints must be resolved before the service can be treated as production-ready?
+
+If those questions are answered, even a solo-developed MVP can become a more credible candidate for business development. That still does not guarantee revenue, customers, or launch approval. But it changes the nature of the work. The next step is no longer simply building more features. It is deciding whether the product, architecture, and sales path are coherent enough to justify a real B2B test.
+
+For product leaders and business development teams trying to move from MVP to B2B sales, that is the decision criterion I would use. Do not ask only whether the product works. Ask whether a business customer can understand how to test it, integrate it, govern it, and eventually buy it. If the answer is not yet clear, the next milestone is not launch. It is product definition.
+
+---

--- a/_posts/2026-06-07-operations-first-ai-service-design.md
+++ b/_posts/2026-06-07-operations-first-ai-service-design.md
@@ -1,0 +1,73 @@
+---
+layout: post
+title: "Operations-first AI Service Design: Privacy, Review, and Launch Constraints"
+date: 2026-06-07 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [Operations, Privacy, QA, Launch Readiness, AI Service]
+---
+
+# An MVP Is Not Yet a Business Service
+
+## Why AI Service Design Has to Start with Operations, Privacy, and Launch Constraints
+
+The easiest mistake in an AI service project is to treat the working demo as the point where the business starts. The model responds. The screen renders. The core flow can be explained in a few minutes. From the builder’s side, this feels like a product crossing an important threshold.
+
+But in a business service, especially one that touches user data, diagnosis-like interpretation, or workflow decisions, the threshold is different. The question is not only whether the AI feature works. The question is whether the service can be reviewed, sold, operated, monitored, corrected, and launched without depending on heroic manual judgment each time something goes wrong.
+
+That distinction matters because many AI ideas are convincing at the feature level but incomplete at the service level. A prototype can show what the user might receive. A business service must also define who the user is, what risk the provider accepts, what data is handled, what the sales path looks like, how quality is checked, and what happens when the system produces a weak answer. The gap between those two states is not cosmetic. It is the place where many AI projects stall.
+
+The case frame in this article is an AI-assisted service concept around beauty and skin-related review workflows. The specific domain is important because the product cannot be judged as a generic chat interface. It sits near personal appearance, profile interpretation, and potentially sensitive user expectations. That means privacy, review, QA, and launch constraints are not late-stage administrative tasks. They are part of the product architecture.
+
+The broader lesson is simple: turning an AI idea into a business service requires simultaneous design of the business plan, technical mechanism, go-to-market path, and operating constraints. If those are designed sequentially, the project may still produce an MVP, but the MVP may not be ready to become a service.
+
+## Business Plan
+
+A business plan in this context is not a pitch deck with optimistic adoption curves. It is a set of claims about who has the problem, why the proposed workflow is better than the current alternative, and what kind of buyer or user would attach the service to an actual business process. For an AI service, this matters because model capability alone does not define willingness to use or pay.
+
+In the beauty and skin review context, the product logic has to stay close to the domain. A general AI assistant may offer advice, but a service has to be framed around a specific job: helping users, staff, or business operators interpret inputs consistently enough to support a workflow. The value proposition is therefore not “AI can answer questions.” It is closer to “AI can standardize part of a review or recommendation process that would otherwise be slow, inconsistent, or difficult to scale.”
+
+That is a narrower claim, but it is also a stronger one. It avoids pretending that the system has already proved a broad market. It instead defines a plausible operational problem: repeated review work, user-facing explanation, and the need for consistent output quality. From there, the service can be evaluated against concrete requirements rather than abstract enthusiasm.
+
+This also changes how revenue should be discussed. At planning stage, it is reasonable to describe monetization assumptions, possible B2B attachment, PoC routes, or API productization logic. It is not reasonable to describe those as confirmed revenue, signed customers, or proven demand unless those facts exist. The useful business question is not “How big could this become?” but “What minimum proof would show that this workflow is valuable enough for a buyer to integrate?”
+
+## Architecture
+
+The technical architecture should then be explained as a mechanism, not as an inventory of tools. In many AI product narratives, the architecture section becomes a list: model, backend, frontend, database, API. That is not enough. A business service architecture needs to show how inputs become outputs, where quality controls sit, how privacy boundaries are enforced, and how the system behaves under failure or uncertainty.
+
+For this type of service, a reviewable architecture should separate an input capture layer, an AI interpretation layer, a business-rule or prompt-control layer, a review or QA process, and a delivery interface. The key point is not that each part exists. The key point is that each part reduces a specific operational risk.
+
+Input capture defines what the service is allowed to know. The interpretation layer produces structured output rather than uncontrolled prose. The review layer catches weak or risky outputs. The delivery layer limits how the result is presented to the user. Logging and monitoring make later investigation possible. These are not enterprise decorations. They are the difference between a demo and an accountable service.
+
+This is especially important when the product touches privacy-sensitive or trust-sensitive contexts. A user may treat skin-related feedback as personally meaningful even if the service avoids medical claims. The system therefore needs careful language boundaries. It should not imply diagnosis, guaranteed results, or professional certification unless the provider can support those claims. This is not merely legal caution. It is product honesty.
+
+A similar logic applies to QA. AI output quality is not only a benchmark score. In production, quality means that the service behaves acceptably across ordinary, edge, and ambiguous cases. It means the team has a way to inspect bad outputs, revise prompts or rules, and decide when automation should stop. It also means that the service can reject or defer requests when inputs are insufficient.
+
+This is where operations-first design becomes practical. Instead of asking, “Can the AI answer this?” the team asks, “Under what conditions are we willing to show this answer to a user?” That framing forces the product to define review thresholds, escalation paths, and unacceptable output categories before launch pressure appears.
+
+## GTM
+
+The go-to-market path should be connected to the same operating model. If the product is positioned as a B2B API or workflow component, buyers will not evaluate only the model’s apparent intelligence. They will ask how the service fits into their current process, what data is sent, what explanations are returned, who is responsible for errors, and how the integration is maintained.
+
+However, this does not mean the article should overstate sales maturity. Planning a PoC or designing an API route is not the same as closing customers. At this stage, a useful GTM claim is conditional: the product may become more sellable if the workflow, risk controls, and integration path are clear enough for a buyer to evaluate. That is a service-design claim, not a revenue claim.
+
+## Operations, Privacy, and Launch Readiness
+
+The most important section of the product plan may therefore be the least glamorous one: operations, privacy, review, and launch readiness. These constraints decide whether the product can move beyond internal excitement.
+
+Privacy comes first because the service likely handles user-provided information that may be personal or preference-based. The product must define what data is collected, why it is needed, how long it is retained, who can access it, and whether it is used for improvement. A vague privacy posture is not a small documentation gap. It can block review, reduce buyer confidence, and create avoidable operational risk.
+
+Review readiness is similarly central. If the service is distributed through an app platform or exposed to external users, approval cannot be assumed. The product has to be prepared for review questions around user data, AI-generated advice, disclaimers, content moderation, account flows, and support processes. Until that review is complete, the correct claim is launch preparation, not approved launch.
+
+QA readiness is the third gate. The team needs test cases that reflect the domain rather than generic prompt tests. For a beauty or skin-related service, this could include ambiguous inputs, low-quality inputs or descriptions, unrealistic user expectations, sensitive wording, and cases where the safest response is to narrow the answer. The service should be tested not only for helpfulness but for restraint.
+
+Operational readiness is the fourth gate. A production service needs incident handling, support flows, monitoring, and a way to update behavior without breaking user trust. Even a small team needs a minimum operating loop: observe outputs, classify problems, patch prompts or rules, retest, and document the change. Without that loop, quality depends on memory and manual improvisation.
+
+These gates may feel heavy for an early product, but they are actually a way to protect speed. When privacy, review, and QA are deferred, every launch decision becomes ambiguous. The team has to revisit basic assumptions under pressure. When the gates are designed early, the project can move faster because the boundary conditions are known.
+
+The domain boundary is also worth stating clearly. The lesson generalizes beyond beauty and skin review, but the evidence should not be stretched into every AI service category. The most defensible general rule is that AI services touching personal data, subjective interpretation, or business workflow decisions need operational constraints designed alongside the model and interface. The exact constraints will differ by domain.
+
+For an individual developer or small team, this has a practical implication. The next milestone should not simply be “finish the MVP.” A better milestone is “make the MVP reviewable.” That means the service can be explained to a buyer, evaluated by a reviewer, tested by the team, and operated after launch with known escalation paths.
+
+The difference is subtle but decisive. A finished MVP demonstrates possibility. A reviewable MVP demonstrates readiness to become a service.
+
+The decision criterion I would use is this: before claiming product readiness, ask whether the weakest parts of the service are visible and bounded. If the privacy assumptions are explicit, the QA loop exists, the launch review risks are known, and the sales path is tied to a real workflow, the AI idea has started to become a business service. If those pieces remain implicit, the product may still be impressive, but it is not yet operationally ready.

--- a/_posts/2026-06-14-externalized-cognition-for-solo-builders.md
+++ b/_posts/2026-06-14-externalized-cognition-for-solo-builders.md
@@ -1,0 +1,101 @@
+---
+layout: post
+title: "Externalized Cognition for Solo Builders: Turning Notes, Prompts, and Checklists into a Build System"
+date: 2026-06-14 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [Solo Builder, Externalized Cognition, Notes, Checklists, AI Workflow]
+---
+
+# The Solo Builder’s Second Brain Is Not a Notebook
+
+## Turning AI service ideas into operating systems of notes, prompts, checklists, and decisions
+
+This is a familiar tension in AI-enabled product work. A demo may generate plausible outputs. A prototype may call the right APIs. A screen may show the right workflow. Yet the moment the product is positioned as a business service, the question changes. The issue is no longer whether the model can produce an answer once. The issue is whether the builder can explain the value proposition, reproduce the implementation path, connect the product to a sales motion, satisfy privacy and review constraints, and operate the service without relying on memory.
+
+For a solo builder or a small team, this is where a real bottleneck appears. The limiting factor is not only engineering capacity; in many cases, it is also cognitive continuity. Business assumptions, technical decisions, customer hypotheses, launch constraints, review items, and operational risks all evolve at once. If those elements remain scattered across chats, temporary notes, and implicit memory, the project becomes difficult to steer. The builder may still be busy every day, but the system does not accumulate usable judgment.
+
+That is why I increasingly see externalized cognition as part of the build system itself. Not as personal productivity, and not as a generic note-taking habit. In an AI service project, notes, prompts, checklists, decision logs, and structured handoff documents become the mechanism that keeps the service concept coherent as it moves from idea to implementation.
+
+The core lesson is simple but demanding: an AI idea becomes a business service only when the key business, technical, go-to-market, and operational constraints are designed together. If those four tracks are handled sequentially, the project may still produce software, but it is less likely to produce a service that can be sold, reviewed, maintained, and improved.
+
+## Notes should preserve reasoning, not just information
+
+Many builders keep notes. Fewer keep reasoning.
+
+A project note that says “add onboarding,” “improve prompt,” or “prepare privacy page” may help with task recall, but it does not preserve the decision logic. The more useful artifact records why the item exists, what assumption it depends on, what risk it reduces, and what would change the decision later.
+
+For example, a note about a skin-analysis workflow should not merely describe the screen or the model behavior. It should connect the workflow to the domain requirement: what kind of user decision the output supports, what claims should be avoided, what level of explanation is acceptable, and where professional or regulatory boundaries may matter. The point is not to overcomplicate a small product. The point is to prevent the product from drifting into claims that the implementation and operating model cannot support.
+
+This kind of note has a different function from documentation written after the fact. It is a thinking surface during development. It allows the builder to revisit a decision without reconstructing the entire mental context. It also makes the project easier to audit: not in the formal compliance sense, but in the practical sense of asking whether the current product still matches the assumptions that justified it.
+
+For a solo builder, this is leverage. The note system becomes a way to turn intermittent thinking into cumulative design.
+
+## Prompts become production scaffolding
+
+In AI projects, prompts are often treated as implementation details. For early experiments, that may be acceptable. For service design, it is too weak.
+
+A prompt is not only a string sent to a model. It is a compact expression of product policy. It encodes what the system should attend to, what it should refuse, what output format should be stable, and what kind of explanation is acceptable. If the prompt changes casually, the product behavior changes casually.
+
+This is why prompts should be versioned and evaluated as part of the build system. A builder should know which prompt supports which user journey, which business claim, and which operational constraint. A prompt used for consumer-facing advice, for example, should not be treated the same as a prompt used to generate an internal diagnostic summary. The risk profile, review burden, and explanation standard differ.
+
+The broader implication is that prompt management is not merely a technical concern. It is part of product definition. The prompt helps translate the business promise into model behavior when the surrounding architecture and review controls are aligned. If the business promise is unclear, the prompt becomes unstable. If the operating constraints are unclear, the prompt may overclaim or produce outputs that are difficult to defend.
+
+This is one reason I find prompt libraries more useful when they are connected to decision logs and checklists. The prompt alone says what the system does. The surrounding artifacts explain why it should do that, when it should not, and what evidence would justify changing it.
+
+## Checklists are a way to make constraints executable
+
+Checklists are often underestimated because they look simple. In a solo-builder AI service, they are one of the most practical ways to convert vague risk into repeatable operation.
+
+The important distinction is between a task checklist and a constraint checklist. A task checklist says what to do next. A constraint checklist says what must remain true while doing it.
+
+For an AI service moving toward production, useful checklists cover questions such as: Is the value proposition still tied to a specific customer problem? Does the current implementation support the claims made in the landing page? Are planned PoC or sales conversations being described too strongly? Does the data flow match the privacy explanation? Is there a fallback when the model response is low-confidence or inappropriate?
+
+These questions are not glamorous, but they protect the project from a common failure mode: making progress in one track while silently creating debt in another. A builder may improve the model output while weakening the compliance posture. They may sharpen the sales narrative while overstating product readiness. They may build a polished interface while leaving monitoring undefined.
+
+A checklist makes those cross-track dependencies visible. It does not guarantee correctness, but it reduces the chance that a project advances by forgetting its own constraints.
+
+## Decision logs prevent strategy from becoming folklore
+
+Small teams often suffer from a quiet form of organizational amnesia. A decision is made in a conversation, implemented in code, reflected in a prompt, and later questioned without anyone remembering the original reason.
+
+For a solo builder, the same problem appears internally. The builder changes their mind many times during the project, often for good reasons. But without a decision log, it becomes hard to distinguish learning from drift.
+
+A decision log does not need to be bureaucratic. It can be concise: decision, context, alternatives considered, reason, expected consequence, revisit trigger. The value is not the format. The value is that the project gains a memory of its own trade-offs.
+
+This matters especially when business planning, technical architecture, and GTM are being designed together. Suppose the product is positioned as a B2B attachment rather than a standalone consumer app. That decision affects pricing logic, API design, onboarding, sales materials, privacy posture, and support expectations. If the decision is not recorded, later work may pull the project back toward a consumer-app pattern without anyone noticing the strategic contradiction.
+
+Decision logs also improve AI-assisted work. A language model can generate options, rewrite plans, and critique assumptions more effectively when the project’s prior decisions are explicit. Without that context, the model tends to produce generic advice. With it, the model can operate against the actual constraints of the service.
+
+## The build system connects business, architecture, GTM, and operations
+
+The practical aim is not to create more documents. The aim is to create a build system in which each artifact has a job.
+
+Business notes define the problem, user, value proposition, and monetization assumptions. Architecture notes explain how the system works and why that mechanism supports the product claim. Prompt records define model behavior and output contracts. GTM notes connect the product to PoC design, sales entry points, and adoption paths. Privacy and operations checklists define what must be true before launch and what must be monitored afterward. Decision logs connect all of these layers over time.
+
+When these artifacts are separate, they become paperwork. When they reference each other, they become infrastructure.
+
+This is the difference between a folder of notes and an externalized cognition system. The system should allow a builder to trace a claim backward and forward. Backward: what evidence or assumption supports this claim? Forward: what implementation, sales, review, or operations work does this claim require?
+
+That traceability is especially important when evidence is still medium-strength. A project may have a plausible problem, a credible implementation plan, and a reasonable PoC path without yet having revenue, signed customers, app review approval, or completed compliance. The artifact system should preserve that distinction. It should make the project stronger by narrowing claims, not by inflating them.
+
+## Domain grounding keeps the system honest
+
+There is a temptation to generalize too quickly from an AI prototype. A workflow that appears useful in one domain may be described as broadly applicable before the domain-specific constraints are understood.
+
+In a beauty or skin-analysis context, for example, the product cannot be evaluated only as a generic AI interface. The domain shapes the input quality, user expectations, explanation style, risk boundaries, privacy concerns, and review requirements. If those are removed, the remaining service description may still sound plausible, but its implementation basis becomes weaker.
+
+This does not mean the lessons are limited to one domain. The broader pattern is transferable: every AI service needs its own grounding layer. In another domain, the grounding may be legal review, financial suitability, manufacturing operations, medical workflow, education policy, or enterprise data governance. The artifact system must capture the constraints that make the service real in that domain.
+
+The general rule is that externalized cognition should not flatten domain specificity into generic templates. It should do the opposite. It should force the builder to write down which parts of the system are generalizable and which parts only work because of the chosen domain.
+
+## The practical test: can the project survive handoff to yourself?
+
+For a solo builder, the most realistic handoff is often not to another person. It is to yourself two weeks later.
+
+Can you reopen the project and understand why the service is positioned this way? Can you see which claims are supported and which are still planning assumptions? Can you identify the next engineering task without losing the sales constraint? Can you revise the prompt without accidentally changing the product promise? Can you prepare a PoC conversation without implying confirmed adoption? Can you discuss privacy and review constraints without pretending they are already solved?
+
+If the answer is no, the problem is not discipline. The problem is that the project does not yet have a cognition system.
+
+The practical takeaway is to treat artifacts as part of the product architecture. For an AI service, the build system is not only code, model calls, and deployment scripts. It is also the structured memory that keeps business planning, technical implementation, GTM, and operations moving together. A solo builder does not gain leverage by remembering more. They gain leverage by designing a system that makes the right constraints hard to forget.
+
+The next decision criterion is therefore straightforward: before adding the next feature, ask whether the project can explain itself. If the answer is weak, the highest-leverage work may not be another screen or another model call. It may be the note, prompt, checklist, or decision log that turns the prototype into a service that can be reviewed, sold, operated, and improved.

--- a/_posts/2026-06-21-evidence-first-service-development-method.md
+++ b/_posts/2026-06-21-evidence-first-service-development-method.md
@@ -1,0 +1,91 @@
+---
+layout: post
+title: "Evidence-first Service Development: A Method to Prevent AI Product Overclaim"
+date: 2026-06-21 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [Evidence-first, Claim Discipline, AI Productization, Writing Assist]
+---
+
+# Evidence Before Narrative: Turning an AI MVP Into a Business Service Without Overclaiming
+
+An MVP can work and still fail to qualify as a business service. That tension becomes especially visible in AI products. A prototype may generate plausible outputs, expose an API, and demonstrate an attractive user flow, yet still leave the harder question unanswered: what exactly can be sold, to whom, under what operational constraints, and with which claims safely supported by evidence?
+
+The practical lesson is simple but demanding: an AI idea becomes a business service only when business planning, technical implementation, go-to-market design, and operational constraints are designed together. Not sequentially, and not as separate documents that happen to reference the same product. They need to constrain one another. The business claim defines what the system must prove. The technical architecture explains how that proof can be produced. The sales path determines what kind of proof matters to a buyer. The operational and privacy constraints define which claims are still permissible at launch.
+
+## The first discipline: define what the service is allowed to claim
+
+A useful starting point is to separate three levels of claim.
+
+The first level is a capability claim: the product can perform a task, such as analyzing an input, generating a recommendation, or producing a structured output. This is usually where an MVP lives. It is the easiest claim to demonstrate and the easiest to overextend.
+
+The second level is a workflow claim: the product can fit into an existing business process. This requires more than model output. It needs input assumptions, review steps, exception handling, and a user or operator who can decide what to do next.
+
+The third level is a commercial claim: the product can be packaged, sold, adopted, and operated in a way that creates value for a specific customer segment. This is where many AI projects become fragile. A demo may show that the system can produce useful output, but it does not automatically show that the service has a buyer, a procurement path, a pricing basis, or a reliable operational model.
+
+For a small team, the temptation is to write across all three levels at once. The product “uses AI to solve a business problem,” “can support enterprise workflows,” and “will enable monetization through B2B adoption.” Those may be reasonable hypotheses. But unless the evidence supports each step, the public claim should remain narrower.
+
+A disciplined article, pitch, or product document should therefore ask: which layer is currently proven, which layer is planned, and which layer remains a hypothesis? This is not modesty for its own sake. It is a way to prevent narrative debt.
+
+## Business planning is not decoration around the MVP
+
+The business plan has a specific function in AI service development. It should not merely describe a market or decorate the product with expected use cases. It should define the customer problem tightly enough that the technical system can be evaluated against it.
+
+In this article, the domain frame is not generic “AI writing” or generic “AI assistance.” The stronger framing is a domain-specific service where evidence boundaries matter because outputs may influence business communication, user trust, or review processes. In the beauty or skin-diagnosis service frame used here, the value of the system does not come from generic fluency alone. It depends on whether the product can respect domain assumptions, avoid unsupported claims, and produce outputs that remain appropriate for review and publication.
+
+That distinction changes the business logic. If the service is treated as a general writing assistant, the proof burden is vague. Almost any coherent generated text looks like progress. But if the service is positioned as an evidence-first assistant for productizing domain-specific AI services, then the business claim becomes narrower and more testable: the system helps teams convert planning evidence into restrained, usable service narratives without overstating launch status, compliance maturity, revenue traction, or customer validation.
+
+This is a better claim because it defines the boundary. It does not say the product has already achieved commercial success. It does not imply that customers have signed or that a store review has passed. It says that the service development process can be made more disciplined by forcing the narrative to follow the available evidence.
+
+## Technical architecture should explain mechanism, not just features
+
+The technical section of an AI product story often becomes a feature list: model selection, API layer, prompt templates, storage, dashboard, review interface. Those details are useful, but they do not yet explain why the system can support the business claim.
+
+A more disciplined technical explanation starts from mechanism. If the product’s core promise is evidence-first claim generation, then the architecture must show how evidence enters the system, how claims are derived from it, how unsupported expansions are prevented, and how outputs remain reviewable. The technical story should answer a causal question: what prevents the system from turning thin evidence into polished exaggeration?
+
+That mechanism may include structured inputs, claim categories, review checkpoints, source-linked reasoning, confidence distinctions, or explicit demotion of weak support. The specific implementation can vary. The important point is that the architecture should not be described as “AI generates better content.” It should be described as a controlled transformation from planning evidence to bounded claims.
+
+The difference between a generic assistant and a service-grade assistant is not just model quality. It is the presence of constraints that shape output behavior. In business settings, uncontrolled fluency can blur the difference between completed work, planned work, assumed value, and speculative future upside.
+
+The architecture should therefore encode friction. It should make some claims harder to produce. It should require stronger support for stronger statements. It should preserve uncertainty where the evidence is medium-strength. It should make it easier to say “planned,” “designed for,” “intended to support,” or “positioned to” when the evidence does not justify “launched,” “proven,” “adopted,” or “validated.”
+
+That kind of technical design may sound less exciting than autonomous generation. But for B2B service development, it is more operationally useful.
+
+## Go-to-market design is part of the product, not an afterthought
+
+A working MVP does not automatically create a sales path. This is particularly important for API-oriented or workflow-embedded AI products. The buyer does not only evaluate whether the system can generate an output. They evaluate whether the system fits a process, reduces a known pain, creates a defensible improvement, and can be adopted with acceptable risk.
+
+For that reason, the go-to-market path should be designed alongside the product definition. If the intended route is PoC-led B2B adoption, the service narrative should remain at the planning and validation level until stronger evidence exists. A PoC plan can support a claim that the product is being structured for customer validation. It cannot support a claim that customers have adopted it. An expression of interest can justify a sales hypothesis. It cannot be written as confirmed revenue.
+
+This distinction is more than legal caution. It affects product design. A PoC-led product needs artifacts that help a buyer evaluate it: scope, success criteria, review process, expected integration points, and failure boundaries. A self-serve product needs a different set of evidence: onboarding, pricing clarity, usage monitoring, support handling, and conversion path. An API product needs yet another layer: interface stability, authentication, usage controls, documentation, and operational support.
+
+When the sales path is unspecified, the product story tends to inflate. It borrows credibility from every possible route without committing to any of them. When the sales path is explicit, the claim becomes narrower but stronger. The product is not “ready for the market” in a vague sense. It is being shaped for a particular adoption motion under particular assumptions.
+
+## Operations, privacy, and review constraints determine launch reality
+
+AI product teams often treat operations as a later stage: first build the MVP, then handle privacy, review, moderation, compliance, monitoring, and support. That sequence is understandable, but it creates a predictable failure mode. The product appears implemented, yet cannot safely be described as launch-ready.
+
+For a service that handles domain-sensitive outputs, operational constraints are not peripheral. They define what the product is. If users rely on generated text for business communication, then review design matters. If the system processes user-provided information, privacy assumptions matter. If the product is distributed through a platform with review requirements, approval status matters. If outputs may be interpreted as advice, the boundary between informational support and regulated or high-risk claims matters.
+
+This is why an evidence-first service narrative must avoid converting incomplete operational work into completed readiness. It is acceptable to say that privacy and review requirements are part of the launch design. It is not acceptable to imply that compliance has been completed if the available evidence only supports planning. It is acceptable to describe operational constraints as known launch dependencies. It is not acceptable to write as though those dependencies have already been resolved.
+
+The same applies to quality. A prototype can show that a system works in controlled examples. A service requires a plan for ordinary failure: ambiguous inputs, missing evidence, contradictory assumptions, edge cases, user misuse, and output review. In many AI products, the operational layer is where the real service begins.
+
+This is also where claim discipline becomes commercially useful. A buyer may tolerate a planning-stage product when the boundary is clear. They are less likely to tolerate a product whose claims exceed its operational maturity.
+
+## Domain grounding creates strength and limits
+
+However, that same specificity limits generalization. Evidence from one domain should not be stretched into a universal claim about all AI product development. The safer claim is that the pattern generalizes at the system level: business planning, technical architecture, sales path, and operational constraints need to be co-designed. The domain evidence supports the pattern, not every possible application of it.
+
+For small teams, this is not a weakness. A narrow, evidence-backed claim is more useful than a broad, inspirational one. It tells the team what to do next.
+
+## The practical takeaway: write only as far as the system has earned
+
+The most useful decision criterion I take from this case is simple: before presenting an AI product as a business service, check whether the evidence supports the full service claim.
+
+If the evidence supports only an MVP, write about the MVP. If it supports a PoC path, write about planned validation. If it supports a technical mechanism, explain the mechanism but do not imply market proof. If privacy, review, or platform approval are still pending, treat them as launch constraints rather than completed credentials. If revenue has not been achieved, do not let the business model section imply that it has.
+
+This may sound restrictive, but it is actually enabling. Claim discipline allows a small team to communicate earlier without pretending to be later. It makes the product more legible to collaborators, buyers, reviewers, and future operators. It also protects the team from the most common AI product writing failure: converting a plausible narrative into an unsupported outcome claim.
+
+The better standard is evidence before narrative. Not because narrative is unimportant, but because narrative is powerful. In AI service development, polished language can easily outrun implementation reality. The task is to make the story move at the same speed as the evidence.
+
+Within this pattern, an AI idea begins to become a business service not through a louder claim, but through a tighter connection between what has been built, what can be sold, what can be operated, and what can be honestly said.

--- a/_posts/2026-06-28-reusable-asset-loop-service-components.md
+++ b/_posts/2026-06-28-reusable-asset-loop-service-components.md
@@ -1,0 +1,85 @@
+---
+layout: post
+title: "Reusable Asset Loop: Converting One Case into Repeatable Service Components"
+date: 2026-06-28 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [Reusable Assets, Templates, Runbooks, API, Service Components]
+---
+
+# From One AI Case to Reusable Service Assets
+
+## Why templates, prompts, runbooks, APIs, and sales materials matter more than the first MVP
+
+An MVP can look deceptively complete. The interface works, the model responds, the core flow produces a plausible output, and the demo is good enough to explain the idea. Yet in many AI-enabled service projects, this is exactly where the hard part begins. The prototype has demonstrated that something can be built, but it has not yet demonstrated that it can become a business service.
+
+I see this distinction most clearly when a single AI use case starts to produce collateral around itself. A skin analysis application, for example, may begin as a diagnostic experience: capture inputs, process them through an AI layer, return recommendations, and package the result in a way that feels useful to an end user. At the MVP level, that is already a meaningful implementation problem. But the moment the same case is considered as a B2B service component, the center of gravity changes. The question is no longer only whether the application works. The question becomes whether the case can generate reusable assets: templates, prompts, runbooks, checklists, APIs, product definitions, privacy documents, review procedures, and sales materials.
+
+That shift is the practical difference between building an AI feature and productizing an AI-enabled business service.
+
+The central lesson is that business planning, technical implementation, go-to-market design, and operational constraints need to be designed together. If they are treated as separate phases, the project can easily produce an impressive artifact that cannot be sold, reviewed, operated, or integrated. Conversely, when these layers are co-designed, one case can become more than a one-off implementation. It can become a seed for repeatable service components.
+
+## The business plan is not decoration
+
+A common failure mode in AI product work is to treat the business plan as a narrative wrapper around the technical artifact. The team builds the model flow first, then later tries to describe the customer, the value proposition, the pricing logic, and the sales path. This sequence feels natural for builders, but it often creates a fragile productization story.
+
+In a B2B context, the business plan has to do more than explain why the product is interesting. It must define what problem the service component solves, who has that problem, why the proposed mechanism fits that domain, and how the buyer would evaluate it. Without that structure, the application remains a demonstration of capability rather than a service that can be attached to a buyer’s workflow.
+
+The skin analysis case illustrates this point because the domain itself matters. A generic AI recommendation engine is not enough. The value proposition depends on the beauty and skin-care context: the user’s concern, the diagnostic framing, the recommendation logic, the expected trust boundary, and the business setting in which the service might be used. If that domain grounding is removed, the project may still contain useful AI mechanics, but the service argument becomes weaker.
+
+This is where reusable assets can start to appear. A business plan can become a positioning template. Customer problem statements can become discovery questions. Competitive assumptions can become sales enablement material. Pricing hypotheses can become testable packaging options. Even if no revenue has yet been achieved, the project can still produce commercially useful artifacts, provided that the artifacts stay honest about their evidentiary status.
+
+## Technical architecture is the mechanism, not the headline
+
+The technical layer also has to change when a case moves toward service productization. In an MVP, architecture is often judged by whether the core user journey functions. In a service component, architecture has to explain why the system can be operated, adapted, and integrated.
+
+For an AI-enabled diagnostic or recommendation service, the technical mechanism is not just “use AI to analyze input.” It includes how input is structured, how prompts or model calls are controlled, how outputs are bounded, how errors are handled, how human review may enter the process, and how downstream systems could consume the result. If the service is intended for B2B use, the API surface becomes especially important. The service needs to expose a stable contract, not merely a user-facing experience.
+
+This is one reason prompts are not trivial implementation details. In a one-off demo, a prompt can be tuned until it produces a good sample response. In a productized service, prompts become part of the operating asset base. They encode domain assumptions, response constraints, tone expectations, safety boundaries, and output schemas. They need versioning, test cases, and review criteria. They also need to be separated from unsupported claims. A prompt that produces confident recommendations beyond the available evidence is not a product asset; it is a liability.
+
+The same applies to templates and checklists. A template for intake, recommendation output, review notes, or partner onboarding is not merely documentation. It is a way of stabilizing the service. It reduces ambiguity, makes quality easier to inspect, and allows the team to reuse the same operating logic across future cases. A checklist for launch readiness, privacy review, or content review serves a similar role. It turns tacit judgment into a repeatable control surface.
+
+In this sense, the architecture of the service extends beyond code. Code is necessary, but the reusable asset loop includes prompts, schemas, API contracts, test fixtures, operating procedures, and review gates. The service definition becomes easier to inspect when these assets connect to one another.
+
+## The sales path must attach to the product definition
+
+A technically working AI service is still incomplete if there is no path from product definition to sales conversation. This is especially true for small teams and individual developers because they rarely have the luxury of building a full product first and discovering the go-to-market motion later.
+
+The useful pattern is to design the sales path as an extension of the product definition. If the service is framed as a B2B API, the sales material should not merely advertise an app-like experience. It should explain what business process the API supports, what inputs it requires, what outputs it returns, what integration burden it creates, and what operational responsibilities remain with the buyer or provider. If the service is framed as an embedded diagnostic component, the sales material should show how it fits inside an existing customer journey.
+
+This is where assets compound. A technical API specification can inform a partner integration guide. The integration guide can inform a sales deck. The sales deck can inform a PoC proposal. The PoC proposal can inform the evaluation checklist. The evaluation checklist can inform the next iteration of the service contract. None of these artifacts proves market success by itself. But together, they create a more coherent path from implementation to business testing.
+
+The key is to avoid confusing readiness artifacts with validated outcomes. A PoC plan is not a customer contract. A sales deck is not market demand. A proposed integration workflow is not evidence that partners will adopt it. Still, these artifacts matter because they make the next commercial test possible. They clarify what would need to be true for the product to move from plausible to validated.
+
+For small teams, this is often the most practical form of progress. The aim is not to build a grand platform immediately. The aim is to convert one concrete case into a set of assets that make the next conversation, next integration, or next pilot more precise.
+
+## Operations and privacy are part of productization
+
+The most underestimated part of AI service development is often not model quality. It is operational acceptability.
+
+A service can be implemented and still fail to become launchable if review, privacy, and operating constraints are added too late. In a domain like skin analysis, this is particularly important because the service may process sensitive user inputs, produce advice-like outputs, or sit close to health-adjacent interpretation. Even when the intended use is cosmetic rather than medical, the boundary must be explicit. The system needs to avoid presenting unsupported conclusions, and the service design needs to define what it does not do.
+
+This is not merely a legal or compliance concern. It shapes the product itself. Privacy requirements affect input design and data retention. Review requirements affect content generation and approval workflows. Operational quality requirements affect monitoring, fallback behavior, and customer support. App review or platform review considerations can affect wording, user consent, and feature presentation. If these constraints are handled after implementation, they can force expensive redesign.
+
+A reusable runbook is therefore a product asset. It defines how the service should be operated, reviewed, escalated, and improved. A privacy checklist is also a product asset. It prevents the team from repeatedly rediscovering the same risks. A launch review checklist can turn vague readiness into inspectable criteria. These artifacts are not glamorous, but they are often what separates a demo from a service that is evaluable by a buyer or platform.
+
+The caveat is that having these documents does not mean compliance is complete. It means the project has begun to express compliance and operations as part of the product system. That is a narrower claim, but it is the right one. In early productization, the goal is to make constraints visible and actionable before they block the launch path.
+
+## The reusable asset loop
+
+The deeper pattern is a loop: one case creates assets, those assets clarify the service, the clarified service improves the next case, and the next case strengthens the asset base.
+
+The loop starts with a concrete implementation. Without a real case, templates become abstract and prompts become generic. The case forces decisions: what information is needed, what output is useful, what risks appear, what the buyer might ask, what the integration needs to expose. Those decisions produce artifacts.
+
+The third pass tests whether these components travel. They do not need to generalize to every domain. In fact, premature generalization can weaken the system. The more realistic goal is controlled reuse: assets that can be reused across adjacent cases while preserving domain-specific constraints. A skin analysis service may produce reusable patterns for AI-assisted recommendation, structured diagnostic intake, B2B API packaging, and review workflows. It should not automatically claim to solve every diagnostic or advisory domain.
+
+This is the practical meaning of productization for an AI-enabled service. Productization is not only turning code into a hosted application. It is turning project-specific decisions into reusable operating assets without pretending that early evidence proves mature scale.
+
+## What this means for builders
+
+For individual developers and small teams, the implication is straightforward: do not measure progress only by whether the MVP works. Measure whether the case is producing reusable assets that make the service more sellable, operable, reviewable, and integrable.
+
+A useful next decision criterion is this: after finishing one AI case, ask what can be reused without copying the whole project. If the only reusable thing is the codebase, the project is still mostly an implementation. If the reusable set includes templates, prompts, runbooks, API definitions, checklists, and sales materials, then the case has started to become a service system.
+
+That does not guarantee revenue, customer adoption, platform approval, or operational maturity. Those require further evidence. But it creates a clearer foundation for testing those outcomes. The service becomes easier to explain, easier to inspect, easier to adapt, and easier to sell in a disciplined way.
+
+When those four layers are designed together, one AI idea can become more than a prototype. It can become the first iteration of a reusable service asset loop.

--- a/_posts/2026-07-05-idea-to-service-os-method-v1.md
+++ b/_posts/2026-07-05-idea-to-service-os-method-v1.md
@@ -1,0 +1,85 @@
+---
+layout: post
+title: "Idea to Service OS v1: A Repeatable Method for AI-built Business Systems"
+date: 2026-07-05 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [Idea to Service OS, Operating Method, AI-built Services, B2B Systems]
+---
+
+# From MVP to Service: A v1 Operating Method for Turning AI Ideas into B2B Systems
+
+*Why product definition, architecture, GTM, and operating constraints have to be designed together*
+
+An MVP can look deceptively complete. The demo works, the core workflow is visible, and the AI behavior is good enough to explain the product idea. Yet the moment the product is expected to become a B2B service, a different set of questions appears. Who is the economic buyer? What operational risk does the workflow create? How does the product attach to an existing sales path? What must be true before a customer can rely on it in daily operations?
+
+That gap is the starting point of this article. A working prototype proves that a product idea can be made tangible. It does not prove that the product is ready to become a business service. In the productization sequence behind this series, the critical transition was not from “idea” to “implementation,” but from “implementation” to “sellable, operable, and reviewable service.”
+
+I do not treat this as a fully validated universal method. It is better understood as a v1 operating method derived from a concrete productization sequence. The evidence supports a narrower but useful claim: when building an AI product for B2B adoption, service readiness emerges from the alignment of product definition, implementation mechanism, sales attachment, and operating constraints. The method is not a guarantee of revenue or customer conversion. It is a way to prevent an MVP from being mistaken for a business system.
+
+## Mistake 1: Defining the product only by its feature
+
+A common AI product definition begins with capability: diagnosis, recommendation, summarization, search, generation, matching, or automation. This is useful for explaining the demo, but too thin for B2B productization. Business buyers rarely purchase an AI capability in isolation. They buy a workflow improvement, a decision support layer, a customer-facing experience, or a cost and quality mechanism that fits into their current operating model.
+
+In the case frame behind this method, the product domain involved beauty and skin diagnosis. That matters because the value proposition cannot be detached from domain context. A generic AI diagnostic workflow may be technically interesting, but the service claim becomes weaker if it ignores the specific customer problem, trust expectations, review process, and business usage pattern of the domain. The same architecture that looks plausible in a general demo may need different evidence when positioned as a professional or commercial tool.
+
+This is the first rule of the operating method: the product should be defined as a business mechanism, not as an AI feature. The mechanism must connect a customer problem, a usage context, a value proposition, and a monetization assumption. Without that connection, the product remains a prototype with possible value rather than a service with a defined commercial role.
+
+The implication is practical. Before expanding engineering scope, the team should be able to state what business process the product enters, what decision or action it improves, who benefits from that improvement, and how that improvement could plausibly support pricing or sales. This does not require proving market size or claiming signed customers. It requires enough business logic to make the next product decision concrete.
+
+## Business planning should constrain the architecture
+
+A second mistake is treating the business plan as a deck and the architecture as a separate engineering artifact. In AI productization, this separation is especially risky because the technical mechanism often determines what can be promised commercially. A product that depends on sensitive inputs, probabilistic outputs, third-party model behavior, or review-sensitive user flows cannot be sold responsibly unless its architecture reflects those constraints.
+
+This is why the method starts from simultaneous design. The business plan should not merely describe the opportunity after the system has been built. It should constrain what the system must do, what it must not do, and where human or organizational control is required. For example, if the value proposition depends on consistent customer-facing recommendations, then output quality, explainability, fallback behavior, and review loops are not secondary details. They are part of the product.
+
+The architecture, in turn, should be described as a causal mechanism. It is not enough to list components such as frontend, API, database, model, storage, or admin interface. The more useful question is how these components produce a serviceable outcome. What input is captured? How is it transformed? Where does the AI system make or support a judgment? How is the result stored, displayed, reviewed, or handed off? What operational trace remains when something goes wrong?
+
+This style of architecture description changes the product conversation. It allows a business owner to see whether the technical system actually supports the service claim. It allows a GTM owner to understand what can be piloted safely. It allows an operations owner to identify which promises require review, logging, privacy handling, or support procedures. Architecture becomes the connective tissue between what the product promises and what the service can actually support.
+
+## GTM is not a final phase; it is part of product definition
+
+A third mistake is assuming that sales begins after the product is built. That may work for some consumer products, but it is a weak model for B2B AI services. In B2B, a product often becomes real only when it can attach to a buying process: a pilot, a proof of concept, an internal champion, an integration path, a budget category, or a measurable operational pain.
+
+In this method, GTM is not treated as promotion. It is treated as service attachment. The question is not only “how do we market this?” but “through what path does this system become a credible purchase?” That distinction matters. A product can be easy to explain and still be hard to buy. It can be attractive to users and still lack a buyer. It can produce a useful output and still fail to connect to a budget or deployment process.
+
+For a B2B API or AI-enabled business system, the sales path should shape the product surface. If the likely entry point is a PoC, then the product needs a pilotable scope, clear evaluation criteria, and a limited-risk usage scenario. If the likely buyer is a platform operator or service provider, then API stability, integration documentation, and operational handoff may matter more than a polished standalone interface. If the likely path depends on partner sales, then packaging, demo narrative, and implementation assumptions become part of the product.
+
+This is why MVP completion is insufficient. A completed MVP can show that the core workflow exists. It does not show that the product has a path into a customer organization. For that, the team needs a sales connection: a defined buyer hypothesis, a deployment unit, a pilot structure, and a reason the buyer would continue after the first test.
+
+The claim should remain disciplined. Planning a PoC is not the same as closing a customer. Designing a sales path is not the same as proving repeatable revenue. But without this path, the team cannot distinguish between a product that is merely demonstrable and a product that is commercially testable.
+
+## Operations and review constraints are not cleanup work
+
+A fourth mistake is pushing privacy, review, and operational quality to the end. In AI services, these constraints often decide whether the product can launch at all. A system can be implemented and still be blocked by review requirements, unclear data handling, insufficient user consent, weak support processes, or platform approval risk.
+
+This is especially important when the product touches personal, diagnostic, or recommendation-sensitive workflows. The product may not need to claim medical or regulated status to create trust and review obligations. If users submit images, personal attributes, preferences, or condition-like information, the service must define how that information is handled. If the system produces advice-like outputs, the product must define the boundary of the recommendation. If the service depends on app distribution or platform review, approval risk becomes a product constraint rather than an administrative afterthought.
+
+The operating method therefore treats review, privacy, and operational quality as part of the architecture. This includes what data is collected, how it is stored, what is retained, what is deleted, what is shown to the user, and what internal process exists when outputs are disputed or fail. It also includes the less glamorous parts of service readiness: monitoring, error handling, support flow, documentation, and version control.
+
+The practical lesson is that implementation progress should not be measured only by feature completion. A more useful readiness view separates prototype readiness, pilot readiness, sales readiness, compliance or review readiness, and operational readiness. These are related, but they are not the same. A product can be technically ready for demonstration while still being unready for customer deployment.
+
+## Domain grounding defines what can be generalized
+
+The method is intended to be repeatable, but not abstract in the empty sense. Its repeatability comes from the structure of the questions, not from ignoring domain differences. The same operating logic can be applied across AI-built business systems, but the answers must change by domain.
+
+In a beauty or skin diagnosis context, domain grounding affects the product promise, user trust, input design, output wording, and commercial path. In another domain, the equivalent constraints may be procurement, workflow integration, model governance, professional liability, latency, data residency, or customer support. The general method is to identify these constraints early and design the business, technical, and GTM layers around them.
+
+This is where many AI product narratives become too broad. They jump from one implemented workflow to a sweeping claim about a market category. The evidence usually supports a more modest and more useful conclusion. A concrete case can show how to structure productization work. It does not automatically prove that the structure is complete, universal, or commercially validated.
+
+That boundary is important. The method described here should be used as an operating frame for the next cycle of product work, not as proof that the service has already succeeded. It helps define what must be true before stronger claims can be made. Revenue evidence, signed customer evidence, approval evidence, compliance evidence, and retention evidence would each strengthen the method in different ways. Until then, the honest claim is that the structure improves readiness for validation.
+
+## The v1 method: design the service before scaling the product
+
+The practical version of the method can be summarized as a sequence of design checks.
+
+First, define the product as a business service, not an AI feature. The minimum unit is a customer problem, a workflow, a value proposition, a buyer or user hypothesis, and a plausible monetization path.
+
+Second, describe the architecture as a mechanism. The system should show how inputs become outputs, how AI behavior is controlled, how the output supports the user or business process, and how the service can be monitored or reviewed.
+
+Third, connect the product to a GTM path before declaring it ready. A B2B product usually needs a route into a customer organization: PoC, pilot, partner channel, API integration, internal champion, or operational wedge.
+
+Fourth, treat privacy, review, and operations as launch constraints. These are not peripheral tasks. They define whether a technically complete system can become a usable service.
+
+Fifth, state evidence boundaries clearly. Do not claim revenue without revenue. Do not claim customers without signed customers. Do not claim approval or compliance before those processes are complete. The method becomes stronger when it narrows claims to what the evidence can support.
+
+That is the core discipline of moving from idea to service. The goal is not to make the prototype more impressive. The goal is to make the system buyable, deployable, reviewable, and operable under real constraints. For product leaders and business development teams trying to connect MVPs to B2B sales, that distinction is the difference between a promising demo and a productization path.


### PR DESCRIPTION
## Summary
- Add 10 future-dated Idea to Service OS posts to `_posts/`
- Set Jekyll scheduling safety in `_config.yml`:
  - `future: false`
  - `timezone: Asia/Tokyo`
- Add scheduled rebuild workflow:
  - `.github/workflows/scheduled-pages-rebuild.yml` (weekly + manual dispatch)

## Included files
- `_config.yml`
- `.github/workflows/scheduled-pages-rebuild.yml`
- `_posts/2026-05-03-beauty-ai-mvp-to-b2b-api.md`
- `_posts/2026-05-10-ai-services-dont-need-to-look-like-ai-products.md`
- `_posts/2026-05-17-from-prompt-to-product-boundary.md`
- `_posts/2026-05-24-architecture-contract-before-model-polish.md`
- `_posts/2026-05-31-gtm-attached-development-design-before-launch.md`
- `_posts/2026-06-07-operations-first-ai-service-design.md`
- `_posts/2026-06-14-externalized-cognition-for-solo-builders.md`
- `_posts/2026-06-21-evidence-first-service-development-method.md`
- `_posts/2026-06-28-reusable-asset-loop-service-components.md`
- `_posts/2026-07-05-idea-to-service-os-method-v1.md`

## Validation
- Local Jekyll build succeeded pre/post promotion.
- Future-date behavior checked with `future: false`:
  - 2026-05-03 post visible (current date after publish date)
  - later 9 posts hidden as expected.
- No PRIVATE REVIEW / internal artifact leakage detected in promoted posts.

## Checklist
- [☑︎] Confirm scheduled workflow policy is acceptable (weekly auto-commit trigger)
- [☑︎] Confirm no private draft artifacts are included
- [☑︎] Confirm future-dated visibility behavior in CI/Pages environment
