### PR TITLE
Add API hypothesis pivot post

### DIFF
--- a/_posts/2026-07-12-api-hypothesis-not-final-product.md
+++ b/_posts/2026-07-12-api-hypothesis-not-final-product.md
@@ -1,0 +1,166 @@
+---
+layout: post
+title: "The API Hypothesis Was Not the Final Product"
+date: 2026-07-12 10:00:00 +0900
+categories: [AI, Product, Startup]
+tags: [API, Productization, Service Design, Data Strategy, Idea to Service OS]
+---
+
+# The API Hypothesis Was a Lens, Not the Packaging
+
+An API can make a product idea look more finished than it really is.
+
+It has a clean boundary. It gives the system a technical surface. It implies that another product, workflow, or organization can call the service and receive a useful result. For a builder moving from prototype to business, that is attractive because it converts a messy capability into something that looks testable.
+
+But the same clarity can become misleading if taken too literally. An API is often a good way to define what the product does. It is not always the way the business should be sold.
+
+That is the tension I now see in the API-first direction. The API direction was not wrong. It was a productive productization hypothesis. It forced the service boundary, integration assumptions, and commercial logic into sharper focus. But the final business packaging does not have to remain API-only.
+The better reading is not that API disappears, but that it moves from the main customer-facing product story to one boundary layer inside a broader adoption package.
+
+The API hypothesis was a useful lens, not necessarily the final packaging.
+
+## The risk of taking the API narrative too literally
+
+Earlier in the process, the API framing created a useful simplification: if this capability can be exposed as an API, then it must have a clear input, a clear output, and a repeatable contract.
+
+That is a valuable discipline.
+
+Many AI prototypes fail before this point. They work in a notebook, a demo script, or a narrow internal workflow, but they do not yet expose a durable product boundary. The user has to understand the prototype’s quirks. The builder has to intervene manually. The output quality may depend on hidden context, implicit assumptions, or one-off prompt adjustments.
+
+An API framing pushes against that ambiguity. It asks: what exactly is the customer sending in, what exactly comes back, and what can be relied on repeatedly?
+
+That question is still valid.
+
+The risk appears when the API narrative becomes interpreted as the destination rather than the diagnostic tool. A reader can easily compress the argument into: “the business should become an API business.” That is too narrow. It confuses one productization lens with the only acceptable commercial form.
+
+The better interpretation is more precise: an API-first hypothesis helps reveal whether the underlying capability can be separated from the founder’s manual effort and exposed through a stable interface.
+
+That is different from saying the customer must ultimately buy a raw API.
+
+## Why the API hypothesis was still useful
+
+The API hypothesis was useful because it forced several hard questions earlier than a broader “AI service” framing would have done.
+
+First, it forced boundary clarity. A service that can be represented as an API needs a defined responsibility. It cannot simply be “AI helps with the workflow.” It must decide which part of the workflow it owns.
+
+That boundary matters because vague AI services are difficult to evaluate. If the service is positioned as general assistance, every customer can project a different expectation onto it. If the service is positioned around a specific transformation, retrieval task, classification task, generation step, enrichment step, or decision-support output, then quality can be discussed more concretely.
+
+Second, it forced integration surface clarity. A business service does not exist in isolation. It has to connect to the customer’s data, process, tools, and decision moments. The API framing asks where that connection happens.
+
+This is especially important for AI products because the hard part is often not model invocation. The hard part is context ingestion, workflow placement, trust calibration, exception handling, and operational repeatability. An API hypothesis exposes these questions because it makes the interface explicit.
+
+Third, it forced commercial assumption clarity. If the product is an API, who is the buyer? Who is the implementer? Is the buyer technical enough to integrate it? Does the customer want a building block, or do they want an outcome? Does pricing map to usage, workflow value, seat count, managed service scope, or some hybrid?
+
+These questions are useful even if the final answer is not “sell the API directly.”
+
+That is why I would not discard the API phase. It did its job. It converted a vague product direction into a sharper set of assumptions that could be examined.
+
+## Product boundary is not the same as business packaging
+
+The main correction is to separate product boundary from business packaging.
+
+A product boundary answers: what does the system own?
+
+Business packaging answers: how does the customer buy and consume it?
+
+These are related, but they are not the same.
+
+A strong product boundary can sit behind several packaging forms. It can be exposed as an API. It can appear inside a dashboard. It can be delivered as a managed workflow. It can support an embeddable component. It can be bundled with onboarding, configuration, reporting, or advisory service.
+
+The underlying capability may still be modular and API-shaped internally. But the customer-facing package may need to be broader because customers rarely buy architecture. They buy reduction in effort, risk, ambiguity, or operational burden.
+
+This distinction is particularly important for AI services moving from MVP to business.
+
+In the MVP stage, the builder often optimizes for proving that the capability works. In the business stage, the question changes. The capability must be packaged into a buying motion that matches the customer’s willingness and ability to adopt it.
+
+A raw API assumes the customer has a technical integration path and wants control over implementation. That can be true for developer platforms, infrastructure tools, and technically mature buyers. But for many applied AI services, the buyer may want something closer to “make this workflow work for us.”
+
+That does not invalidate the API boundary. It changes the surface through which the boundary is delivered.
+That broader surface can include a user-facing app, a PoC-ready diagnostic workflow, reporting and dashboard layers, customer-specific delivery, integration support, and managed operational support, while the API-shaped core remains the contract discipline underneath.
+
+A dashboard may be the right surface when the customer needs visibility and review. A managed workflow may be right when the customer wants operational delegation. Consulting or onboarding may be necessary when the problem requires customer-specific configuration. An API may still remain part of the stack, but not necessarily the whole commercial package.
+
+The business question is not “API or not API.”
+
+The better question is: which packaging form reduces adoption friction while preserving the product boundary that makes the service repeatable?
+
+## Why the packaging moved beyond the endpoint
+
+For many non-technical store or small-business buyers, API-only selling can create a practical implementation burden on the buyer side. Even if the core capability is real, adoption can stall when the offering does not include a PoC-ready diagnostic surface, consent-aware reporting flow, and integration/support layer that fits how the buyer actually works.
+
+There is also a productization pressure specific to the AI era: feature-level differentiation can compress quickly as similar features become easier to replicate. In this framing, the potentially more defensible layer may be accumulated diagnostic or usage patterns, workflow learning, and customer-specific delivery operations around reporting and integration, rather than endpoint exposure alone.
+
+A free or low-friction B2C surface can also play a structured role. It can function as both a user-facing diagnostic surface and a consent-aware data loop, while the B2B package can focus on analysis volume, reporting, customer-specific delivery, integration, and support. This should still be treated as a packaging hypothesis and a likely business logic, not as proof of validated traction.
+
+## What current packaging signals suggest
+
+The current visible packaging signals appear broader than a pure API-only service, as a packaging interpretation rather than proof of operating outcomes.
+
+I would state that cautiously. This does not prove revenue. It does not prove signed customers. It does not prove that the pivot is fully validated. It also does not prove that the business has abandoned API logic internally.
+
+What it suggests is narrower: the visible packaging direction is not limited to a raw API surface.
+If usage data or diagnostic outputs become part of the B2B value proposition, that claim should be framed carefully: not as a proven moat, but as a potential asset that depends on consent, aggregation, governance, and the customer's actual reporting or integration needs.
+
+That matters because it changes how the productization story should be interpreted. The earlier API-first logic should not be read as a fixed commitment to sell only an endpoint. It should be read as an intermediate hypothesis that clarified the product’s contract and integration assumptions.
+
+A broader service package can still preserve that learning. In many cases, it may depend on it.
+
+If the visible materials point toward workflow surfaces, managed elements, dashboards, integration support, or adjacent customer-facing packaging layers, the API phase remains useful because it likely clarified what those layers are wrapping. A dashboard without a clean service boundary becomes a custom reporting tool. A managed workflow without a repeatable core becomes consulting. An integration layer without a defined contract becomes bespoke engineering.
+
+The API hypothesis helps prevent those failure modes.
+
+But packaging has to follow the buyer’s adoption path. If the buyer does not want to assemble the workflow, a pure API may under-package the value. If the buyer needs visibility, review, or handholding, then a dashboard or managed service layer may be more commercially appropriate. If the buyer needs to embed the capability into an existing system, an API may remain central.
+
+The signal to watch is not whether the word “API” remains prominent. The signal to watch is whether the offering preserves a repeatable product boundary while adapting the buying surface to customer behavior.
+A free or low-friction user-facing product can further change this logic. It may operate as a PoC-ready diagnostic surface and a consent-aware learning loop, while the B2B layer focuses on reporting, dashboard interpretation, customer-specific delivery, integration, and support. In this framing, API does not disappear; it remains a contract and implementation layer even when it is no longer the whole customer-facing package.
+
+That is a more useful reading of the pivot.
+
+## Productization is a search process, not plan loyalty
+
+This case reinforces a broader rule: productization is a search process, not loyalty to the first clean architecture.
+
+The first strong framing is rarely the final business. Its job is to create constraints that make learning possible.
+
+A bad hypothesis is vague and unfalsifiable. A useful hypothesis is specific enough to expose what must be true. The API hypothesis was useful because it made several assumptions testable: the product could be bounded, integrated, evaluated, and potentially sold as a reusable service.
+
+Once those assumptions become clearer, the builder can update the packaging.
+
+That update should not be treated as failure. It is part of the process.
+
+The mistake would be to throw away the discipline of the API phase and drift back into vague service work. The opposite mistake would be to defend the API packaging even when customer adoption patterns suggest a broader bundle is needed.
+
+Both errors come from confusing hypothesis with identity.
+
+A hypothesis is a tool for learning. A package is a tool for adoption. They should inform each other, but neither should be treated as sacred.
+
+For AI service builders, this matters because the technology often makes prototype creation deceptively fast. It is easy to generate a demo, wrap it in a thin interface, and call it a product. But the business only becomes real when the service can be adopted, evaluated, paid for, and operated with acceptable friction.
+
+The API lens helps with the “can this be made repeatable?” question.
+
+The packaging lens helps with the “can the customer actually buy and use this?” question.
+
+
+## A practical decision rule for AI service builders
+
+The practical takeaway is simple: use the API hypothesis to define the product boundary, then let customer adoption evidence determine the packaging.
+
+When evaluating an AI service, I would separate the decision into three layers.
+
+First, define the core contract. What input does the service accept? What output does it produce? What quality level is expected? What failure modes are acceptable? What parts of the workflow are inside the product boundary, and what parts remain outside?
+
+This is where API thinking is powerful, even if no public API is ever sold.
+
+Second, identify the adoption surface. Does the customer want to integrate the capability into their own system? Do they need a dashboard to inspect outputs? Do they want a managed workflow? Do they require onboarding, configuration, or periodic review? Is the user technical, operational, managerial, or some mix?
+
+This is where packaging may diverge from the internal architecture.
+
+Third, choose the commercial wrapper. Usage-based API pricing, subscription dashboard access, managed service fees, implementation packages, workflow-based pricing, or hybrid models each imply different buyer expectations. The right wrapper is the one that matches how the customer perceives value and risk.
+
+The decision criterion I would use is this:
+
+If the customer primarily wants a building block and has the ability to integrate it, keep the API prominent. If the customer primarily wants an operational outcome, package the API-shaped capability inside a workflow, dashboard, managed service, or broader solution layer. If the customer needs both, preserve the API as the core contract but sell the adoption layer around it.
+
+That is the pivot I would draw from this case.
+
+The API direction was not a mistake. It clarified the product boundary. But product boundary is not the same as business packaging. The useful move is to preserve the learning from the API hypothesis while allowing the service package to evolve as the evidence changes.


### PR DESCRIPTION
## Update
- Add #11 follow-up post: `The API Hypothesis Was Not the Final Product`
- Clarifies that the API framing was a productization lens, not a claim that the final business packaging is API-only
- Explains the shift toward broader diagnostic UX, consent-aware data/reporting, integration, and support packaging